### PR TITLE
Fixed hardcoded bucket name

### DIFF
--- a/restream.py
+++ b/restream.py
@@ -84,7 +84,7 @@ def restream(bucket, key, stream, start, end, yes, delimiter):
 
         for s3_object in contents:
             object_response = s3.get_object(
-                Bucket='buffer-data',
+                Bucket=bucket,
                 Key=s3_object.get('Key')
             )
 


### PR DESCRIPTION
Hi,

I was trying to use your restreaming tool and was having trouble due to what appeared to be a incorrectly hardcoded bucket name when trying to get the object out of the s3 bucket.  When I applied this fix locally the restream tool then appeared to work.

Thanks for providing such a great tool!

Regards,
Dave